### PR TITLE
Feat: Powervault v4 API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powervaultpy"
-version = "1.0.3"
+version = "1.1.0"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -44,7 +44,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "1.0.3"
+current_version = "1.1.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dev = [
   "pytest-env",
   "pytest-asyncio",
   "bumpver",
-  "pre-commit"
+  "pre-commit",
+  "python-dotenv",
 ]
 
 [project.urls]

--- a/src/powervaultpy/powervault.py
+++ b/src/powervaultpy/powervault.py
@@ -50,8 +50,7 @@ class PowerVault:
     ) -> None:
         """API Client."""
         self._api_key = api_key
-        self._base_url = "http://rest-api-v2.powervault.co.uk"
-        self._base_url_state = "https://api.p3.powervault.co.uk/v3"
+        self._base_url = "https://rest-api.powervault.co.uk/v4"
         self._session = session or requests.Session()
 
         self._session.headers.update(
@@ -178,7 +177,7 @@ class PowerVault:
 
     def set_battery_state(self, unit_id: str, battery_state) -> bool:
         """Override the current battery status with the provided one."""
-        url = f"{self._base_url_state}/unit/{unit_id}/stateOverride"
+        url = f"{self._base_url}/unit/{unit_id}/stateOverride"
 
         start_time = datetime.now(pytz.timezone('UTC')).strftime("%Y-%m-%d %H:%M:%S")
         end_time = (datetime.now(pytz.timezone('UTC')) + timedelta(hours=24)).strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Implements: https://github.com/adammcdonagh/powervaultpy/issues/1

This pull request introduces several updates to the `powervaultpy` project, including enhancements to versioning, dependencies, API client functionality, and integration tests. The most significant changes involve updating the API URLs, adding support for `.env` files, and improving test coverage for battery state management.

### Project Configuration Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated project version from `1.0.3` to `1.1.0` and added `python-dotenv` to the development dependencies for environment variable management. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34-R35) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R47)

### API Client Enhancements:
* [`src/powervaultpy/powervault.py`](diffhunk://#diff-2eb7910b925e7450f3217034751b898ed2ab80fc9cb454b3265c3f86e014bbd2L53-R53): Updated the base API URL to `https://rest-api.powervault.co.uk/v4` to reflect the latest API version. Removed the separate `_base_url_state` variable and consolidated its usage into `_base_url`. [[1]](diffhunk://#diff-2eb7910b925e7450f3217034751b898ed2ab80fc9cb454b3265c3f86e014bbd2L53-R53) [[2]](diffhunk://#diff-2eb7910b925e7450f3217034751b898ed2ab80fc9cb454b3265c3f86e014bbd2L181-R180)

### Integration Test Improvements:
* `tests/integration/api/test_get_account.py`: 
  - Added support for loading API keys from a `.env` file using `python-dotenv`.
  - Introduced a new test `test_get_unit()` to verify unit retrieval functionality.
  - Enhanced `test_set_battery_state()` to restore the original battery state after testing, ensuring no persistent changes are made during tests. [[1]](diffhunk://#diff-ea81f631312097706ec970b719efa296a6f4b8fc12832ff57a220344875492c9L148-R172) [[2]](diffhunk://#diff-ea81f631312097706ec970b719efa296a6f4b8fc12832ff57a220344875492c9R183-R189)